### PR TITLE
Updated npm dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ cd helloworld
 npm install
 ```
 
+Install the command line tool:
+
+```
+npm install runtime-cli -g
+```
+
 ### Run
 
 Make sure you have QEMU installed, then

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "start": "runtimeify index.js -o initrd && runtime-qemu ./initrd"
+    "start": "runtime start"
   },
   "repository": {
     "type": "git",
@@ -12,9 +12,5 @@
   "license": "MIT",
   "dependencies": {
     "runtimejs": "*"
-  },
-  "devDependencies": {
-    "runtime-tools": "*",
-    "runtimeify": "*"
   }
 }


### PR DESCRIPTION
As runtimeify and runtime-tools have been deprecated and replaced by runtime-cli
